### PR TITLE
Support for the args method

### DIFF
--- a/Process.pm
+++ b/Process.pm
@@ -607,8 +607,13 @@ B<F6> means the method returns something useful for FreeBSD
 
 =item process_args, args
 
-The command line arguments passed to the program. CURRENTLY
-UNIMPLEMENTED.
+The command with all its arguments as a string. When the process
+args are unavailable, the name of the executable in brackets is
+returned (same as in the F<ps> program). This may happen when the
+length of the arguments exceeds the kernel limit set with the
+C<kern.ps_arg_cache_limit> kernel setting. (This is usually 256,
+for more information check the manual page for the F<sysctl>
+program.)
 
 =item process_pid, pid
 

--- a/Process.xs
+++ b/Process.xs
@@ -245,22 +245,25 @@ HV *_procinfo (struct kinfo_proc *kp, int resolve) {
     }
 
     if( argv && *argv ) {
-#ifdef NEVER
         len = strlen(*argv);
+
         argsv = newSVpvn(*argv, len);
         while (*++argv) {
             sv_catpvn(argsv, " ", 1);
             sv_catpvn(argsv, *argv, strlen(*argv));
-            len += strlen(*argv)+1;
         }
-        hv_store(h, "args", 4, argsv, 0);
-#else
-        hv_store(h, "args", 4, newSVpvn("", 0), 0);
-#endif
     }
     else {
-        hv_store(h, "args", 4, newSVpvn("", 0), 0);
+        /* sometimes the process args may be unavailable; when this happens the name
+         * of the executable in brackets is returned, similar to the ps program.
+         */
+        argsv = newSVpvn("[", 1);
+        sv_catpvn(argsv, kp->COMM_FIELD, strlen(kp->COMM_FIELD));
+        sv_catpvn(argsv, "]", 1);
     }
+
+    hv_store(h, "args", 4, argsv, 0);
+
     if (kd) {
         kvm_close(kd);
     }


### PR DESCRIPTION
This method was flagged as unimplemented.  It now
returns the process command line (or the name of
the executable in brackets when the full command
line cannot be retrieved).

https://github.com/az5112/BSD-Process/commit/ad24a07c388aa210659e107ecb7f92e8bd8f69aa
