### PR TITLE
Proposed fix for RT #88975

### DIFF
--- a/Process.pm
+++ b/Process.pm
@@ -18,7 +18,9 @@ $VERSION = '0.07';
 
 @EXPORT_OK = (qw(process_info process_list P));
 
-BEGIN {
+XSLoader::load __PACKAGE__, $VERSION;
+
+{
     my %alias = (
         process_pid              => 'pid',
         parent_pid               => 'ppid',
@@ -62,7 +64,7 @@ BEGIN {
         posix_advisory_lock      => 'advlock',
         has_controlling_terminal => 'controlt',
         is_kernel_thread         => 'kthread',
-        no_loadavg_calc          => 'noload',
+        (has_noload_field() ? (no_loadavg_calc => 'noload') : ()),
         parent_waiting           => 'ppwait',
         started_profiling        => 'profil',
         stopped_profiling        => 'stopprof',
@@ -156,8 +158,6 @@ BEGIN {
         return keys(%alias);
     }
 }
-
-XSLoader::load __PACKAGE__, $VERSION;
 
 sub new {
     my $class = shift;

--- a/Process.xs
+++ b/Process.xs
@@ -49,6 +49,10 @@
 #define NO_FREEBSD_5x_pv(a) (a)
 #endif
 
+#if __FreeBSD_version < 802501
+#define HAS_NOLOAD_FIELD
+#endif
+
 static int proc_info_mib[4] = { -1, -1, -1, -1 };
 
 struct kinfo_proc *_proc_request (kvm_t *kd, int request, int param, int *pnr) {
@@ -292,7 +296,7 @@ HV *_procinfo (struct kinfo_proc *kp, int resolve) {
     hv_store(h, "advlock",      7, newSViv(NO_FREEBSD_4x(P_FLAG(P_ADVLOCK))), 0);
     hv_store(h, "controlt",     8, newSViv(NO_FREEBSD_4x(P_FLAG(P_CONTROLT))), 0);
     hv_store(h, "kthread",      7, newSViv(NO_FREEBSD_4x(P_FLAG(P_KTHREAD))), 0);
-#if __FreeBSD_version < 802501
+#ifdef HAS_NOLOAD_FIELD
     hv_store(h, "noload",       6, newSViv(NO_FREEBSD_4x(P_FLAG(P_NOLOAD))), 0);
 #endif
     hv_store(h, "ppwait",       6, newSViv(NO_FREEBSD_4x(P_FLAG(P_PPWAIT))), 0);
@@ -387,6 +391,17 @@ max_kernel_groups()
         RETVAL = 0;
 #else
         RETVAL = KI_NGROUPS;
+#endif
+    OUTPUT:
+        RETVAL
+
+short
+has_noload_field()
+    CODE:
+#ifdef HAS_NOLOAD_FIELD
+        RETVAL = 1;
+#else
+        RETVAL = 0;
 #endif
     OUTPUT:
         RETVAL

--- a/t/01-func.t
+++ b/t/01-func.t
@@ -61,7 +61,11 @@ ok( defined( delete $info->{childtime} ), 'attribute childtime');
 ok( defined( delete $info->{advlock} ), 'attribute advlock');
 ok( defined( delete $info->{controlt} ), 'attribute controlt');
 ok( defined( delete $info->{kthread} ), 'attribute kthread');
-ok( defined( delete $info->{noload} ), 'attribute noload');
+SKIP: {
+    skip "noload not available, probably FreeBSD 9 or newer", 1
+	if !BSD::Process::has_noload_field;
+    ok( defined( delete $info->{noload} ), 'attribute noload');
+}
 ok( defined( delete $info->{ppwait} ), 'attribute ppwait');
 ok( defined( delete $info->{profil} ), 'attribute profil');
 ok( defined( delete $info->{stopprof} ), 'attribute stopprof');

--- a/t/02-method.t
+++ b/t/02-method.t
@@ -67,7 +67,11 @@ plan tests => 242
     is($pe->advlock,     delete $pe->{advlock},     'method advlock');
     is($pe->controlt,    delete $pe->{controlt},    'method controlt');
     is($pe->kthread,     delete $pe->{kthread},     'method kthread');
-    is($pe->noload,      delete $pe->{noload},      'method noload');
+    SKIP: {
+        skip "noload not available, probably FreeBSD 9 or newer", 1
+	    if !BSD::Process::has_noload_field;
+        is($pe->noload,      delete $pe->{noload},      'method noload');
+    }
     is($pe->ppwait,      delete $pe->{ppwait},      'method ppwait');
     is($pe->profil,      delete $pe->{profil},      'method profil');
     is($pe->stopprof,    delete $pe->{stopprof},    'method stopprof');
@@ -195,7 +199,11 @@ plan tests => 242
     is($pe->posix_advisory_lock,           delete $pe->{advlock},     'alias posix_advisory_lock');
     is($pe->has_controlling_terminal,      delete $pe->{controlt},    'alias has_controlling_terminal');
     is($pe->is_kernel_thread,              delete $pe->{kthread},     'alias is_kernel_thread');
-    is($pe->no_loadavg_calc,               delete $pe->{noload},      'alias no_loadavg_calc');
+    SKIP: {
+        skip "noload not available, probably FreeBSD 9 or newer", 1
+	    if !BSD::Process::has_noload_field;
+        is($pe->no_loadavg_calc,               delete $pe->{noload},      'alias no_loadavg_calc');
+    }
     is($pe->parent_waiting,                delete $pe->{ppwait},      'alias parent_waiting');
     is($pe->started_profiling,             delete $pe->{profil},      'alias started_profiling');
     is($pe->stopped_profiling,             delete $pe->{stopprof},    'alias stopped_profiling');


### PR DESCRIPTION
Here's a possible fix for skipping tests dealing with noload on FreeBSD 9. I found it best to invent a new function has_noload_field(), so it can be used in all the tests.

Regards,
    Slaven
